### PR TITLE
fix: APIPath mapping

### DIFF
--- a/internal/provider/indexer_newznab_resource.go
+++ b/internal/provider/indexer_newznab_resource.go
@@ -70,7 +70,7 @@ func (i IndexerNewznab) toIndexer() *Indexer {
 		Name:                    i.Name,
 		AdditionalParameters:    i.AdditionalParameters,
 		APIKey:                  i.APIKey,
-		APIPath:                 i.APIKey,
+		APIPath:                 i.APIPath,
 		BaseURL:                 i.BaseURL,
 		MultiLanguages:          i.MultiLanguages,
 		Categories:              i.Categories,


### PR DESCRIPTION
The API Key for Newznab indexers is currently being used as both the API Key and the API Path, making the `radarr_indexer_newznab` fail with the following error:

> Unable to update indexer_newznab, got error: 400 Bad Request
> Details:
> [
>   {
>     "isWarning": false,
>     "propertyName": "",
>     "errorMessage": "Unable to connect to indexer, please check your DNS settings and ensure IPv6 is working or disabled. Name does not resolve (newznab-host.tldapi-key:443)",
>     "severity": "error"
>   }
> ]
