### PR TITLE
feat: add map_from and map_to to emby and plex notifications

### DIFF
--- a/docs/data-sources/notification.md
+++ b/docs/data-sources/notification.md
@@ -71,8 +71,8 @@ data "radarr_notification" "example" {
 - `include_health_warnings` (Boolean) Include health warnings.
 - `instance_name` (String) Instance name.
 - `key` (String) Key.
-- `map_from` (String) Map From.
-- `map_to` (String) Map To.
+- `map_from` (String) Map from. Radarr path, used to modify movie paths when the media server sees library path location differently from Radarr (Requires 'Update Library')
+- `map_to` (String) Map to. Media server path, used to modify movie paths when the media server sees library path location differently from Radarr (Requires 'Update Library')
 - `mention` (String) Mention.
 - `method` (Number) Method. `1` POST, `2` PUT.
 - `notification_type` (Number) Notification type. `0` Info, `1` Success, `2` Warning, `3` Failure.

--- a/docs/data-sources/notifications.md
+++ b/docs/data-sources/notifications.md
@@ -74,8 +74,8 @@ Read-Only:
 - `include_health_warnings` (Boolean) Include health warnings.
 - `instance_name` (String) Instance name.
 - `key` (String) Key.
-- `map_from` (String) Map From.
-- `map_to` (String) Map To.
+- `map_from` (String) Map from. Radarr path, used to modify movie paths when the media server sees library path location differently from Radarr (Requires 'Update Library')
+- `map_to` (String) Map to. Media server path, used to modify movie paths when the media server sees library path location differently from Radarr (Requires 'Update Library')
 - `mention` (String) Mention.
 - `method` (Number) Method. `1` POST, `2` PUT.
 - `name` (String) Notification name.

--- a/docs/resources/notification.md
+++ b/docs/resources/notification.md
@@ -90,8 +90,8 @@ resource "radarr_notification" "example" {
 - `include_health_warnings` (Boolean) Include health warnings.
 - `instance_name` (String) Instance name.
 - `key` (String) Key.
-- `map_from` (String) Map From.
-- `map_to` (String) Map To.
+- `map_from` (String) Map from. Radarr path, used to modify movie paths when the media server sees library path location differently from Radarr (Requires 'Update Library')
+- `map_to` (String) Map to. Media server path, used to modify movie paths when the media server sees library path location differently from Radarr (Requires 'Update Library')
 - `mention` (String) Mention.
 - `method` (Number) Method. `1` POST, `2` PUT.
 - `notification_type` (Number) Notification type. `0` Info, `1` Success, `2` Warning, `3` Failure.

--- a/docs/resources/notification_emby.md
+++ b/docs/resources/notification_emby.md
@@ -34,6 +34,11 @@ resource "radarr_notification_emby" "example" {
   host    = "emby.lcl"
   port    = 8096
   api_key = "API_Key"
+
+  # Path mapping is only applied when update_library is enabled.
+  update_library = true
+  map_from       = "/movies"
+  map_to         = "/media/movies"
 }
 ```
 
@@ -50,6 +55,8 @@ resource "radarr_notification_emby" "example" {
 ### Optional
 
 - `include_health_warnings` (Boolean) Include health warnings.
+- `map_from` (String) Map from. Radarr path, used to modify movie paths when Jellyfin sees library path location differently from Radarr (Requires 'Update Library')
+- `map_to` (String) Map to. Jellyfin path, used to modify movie paths when Jellyfin sees library path location differently from Radarr (Requires 'Update Library')
 - `notify` (Boolean) Notify flag.
 - `on_application_update` (Boolean) On application update flag.
 - `on_download` (Boolean) On download flag.

--- a/docs/resources/notification_plex.md
+++ b/docs/resources/notification_plex.md
@@ -31,6 +31,11 @@ resource "radarr_notification_plex" "example" {
   host       = "plex.lcl"
   port       = 32400
   auth_token = "AuthTOKEN"
+
+  # Path mapping is only applied when update_library is enabled.
+  update_library = true
+  map_from       = "/movies"
+  map_to         = "/media/movies"
 }
 ```
 
@@ -47,6 +52,8 @@ resource "radarr_notification_plex" "example" {
 ### Optional
 
 - `include_health_warnings` (Boolean) Include health warnings.
+- `map_from` (String) Map from. Radarr path, used to modify movie paths when Plex sees library path location differently from Radarr (Requires 'Update Library')
+- `map_to` (String) Map to. Plex path, used to modify movie paths when Plex sees library path location differently from Radarr (Requires 'Update Library')
 - `on_download` (Boolean) On download flag.
 - `on_movie_added` (Boolean) On movie added flag.
 - `on_movie_file_delete` (Boolean) On movie file delete flag.

--- a/examples/resources/radarr_notification_emby/resource.tf
+++ b/examples/resources/radarr_notification_emby/resource.tf
@@ -16,4 +16,10 @@ resource "radarr_notification_emby" "example" {
   host    = "emby.lcl"
   port    = 8096
   api_key = "API_Key"
+
+  # optional path mapping, for when Radarr and Emby/Jellyfin see the library at
+  # different paths. only applied when update_library is enabled.
+  update_library = true
+  map_from       = "/movies"
+  map_to         = "/media/movies"
 }

--- a/examples/resources/radarr_notification_plex/resource.tf
+++ b/examples/resources/radarr_notification_plex/resource.tf
@@ -13,4 +13,10 @@ resource "radarr_notification_plex" "example" {
   host       = "plex.lcl"
   port       = 32400
   auth_token = "AuthTOKEN"
+
+  # optional path mapping, for when Radarr and Plex see the library at different
+  # paths. only applied when update_library is enabled.
+  update_library = true
+  map_from       = "/movies"
+  map_to         = "/media/movies"
 }

--- a/internal/provider/notification_data_source.go
+++ b/internal/provider/notification_data_source.go
@@ -323,11 +323,11 @@ func (d *NotificationDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 				Computed:            true,
 			},
 			"map_from": schema.StringAttribute{
-				MarkdownDescription: "Map From.",
+				MarkdownDescription: "Map from. Radarr path, used to modify movie paths when the media server sees library path location differently from Radarr (Requires 'Update Library')",
 				Computed:            true,
 			},
 			"map_to": schema.StringAttribute{
-				MarkdownDescription: "Map To.",
+				MarkdownDescription: "Map to. Media server path, used to modify movie paths when the media server sees library path location differently from Radarr (Requires 'Update Library')",
 				Computed:            true,
 			},
 			"key": schema.StringAttribute{

--- a/internal/provider/notification_emby_resource.go
+++ b/internal/provider/notification_emby_resource.go
@@ -44,6 +44,8 @@ type NotificationEmby struct {
 	Host                        types.String `tfsdk:"host"`
 	APIKey                      types.String `tfsdk:"api_key"`
 	Name                        types.String `tfsdk:"name"`
+	MapFrom                     types.String `tfsdk:"map_from"`
+	MapTo                       types.String `tfsdk:"map_to"`
 	ID                          types.Int64  `tfsdk:"id"`
 	Port                        types.Int64  `tfsdk:"port"`
 	UpdateLibrary               types.Bool   `tfsdk:"update_library"`
@@ -69,6 +71,8 @@ func (n NotificationEmby) toNotification() *Notification {
 		Host:                        n.Host,
 		Name:                        n.Name,
 		APIKey:                      n.APIKey,
+		MapFrom:                     n.MapFrom,
+		MapTo:                       n.MapTo,
 		ID:                          n.ID,
 		Port:                        n.Port,
 		UpdateLibrary:               n.UpdateLibrary,
@@ -96,6 +100,8 @@ func (n *NotificationEmby) fromNotification(notification *Notification) {
 	n.Host = notification.Host
 	n.Name = notification.Name
 	n.APIKey = notification.APIKey
+	n.MapFrom = notification.MapFrom
+	n.MapTo = notification.MapTo
 	n.ID = notification.ID
 	n.UpdateLibrary = notification.UpdateLibrary
 	n.Port = notification.Port
@@ -228,6 +234,16 @@ func (r *NotificationEmbyResource) Schema(_ context.Context, _ resource.SchemaRe
 			"host": schema.StringAttribute{
 				MarkdownDescription: "Host.",
 				Required:            true,
+			},
+			"map_from": schema.StringAttribute{
+				MarkdownDescription: "Map from. Radarr path, used to modify movie paths when Jellyfin sees library path location differently from Radarr (Requires 'Update Library')",
+				Optional:            true,
+				Computed:            true,
+			},
+			"map_to": schema.StringAttribute{
+				MarkdownDescription: "Map to. Jellyfin path, used to modify movie paths when Jellyfin sees library path location differently from Radarr (Requires 'Update Library')",
+				Optional:            true,
+				Computed:            true,
 			},
 		},
 	}

--- a/internal/provider/notification_emby_resource_test.go
+++ b/internal/provider/notification_emby_resource_test.go
@@ -25,6 +25,8 @@ func TestAccNotificationEmbyResource(t *testing.T) {
 				Config: testAccNotificationEmbyResourceConfig("resourceEmbyTest", "token123"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("radarr_notification_emby.test", "api_key", "token123"),
+					resource.TestCheckResourceAttr("radarr_notification_emby.test", "map_from", "/movies"),
+					resource.TestCheckResourceAttr("radarr_notification_emby.test", "map_to", "/media/movies"),
 					resource.TestCheckResourceAttrSet("radarr_notification_emby.test", "id"),
 				),
 			},
@@ -72,5 +74,9 @@ func testAccNotificationEmbyResourceConfig(name, token string) string {
 		host = "emby.lcl"
 		port = 8096
 		api_key = "%s"
+
+		update_library = true
+		map_from       = "/movies"
+		map_to         = "/media/movies"
 	}`, name, token)
 }

--- a/internal/provider/notification_plex_resource.go
+++ b/internal/provider/notification_plex_resource.go
@@ -44,6 +44,8 @@ type NotificationPlex struct {
 	Host                        types.String `tfsdk:"host"`
 	AuthToken                   types.String `tfsdk:"auth_token"`
 	Name                        types.String `tfsdk:"name"`
+	MapFrom                     types.String `tfsdk:"map_from"`
+	MapTo                       types.String `tfsdk:"map_to"`
 	ID                          types.Int64  `tfsdk:"id"`
 	Port                        types.Int64  `tfsdk:"port"`
 	UpdateLibrary               types.Bool   `tfsdk:"update_library"`
@@ -64,6 +66,8 @@ func (n NotificationPlex) toNotification() *Notification {
 		Host:                        n.Host,
 		Name:                        n.Name,
 		AuthToken:                   n.AuthToken,
+		MapFrom:                     n.MapFrom,
+		MapTo:                       n.MapTo,
 		ID:                          n.ID,
 		Port:                        n.Port,
 		UpdateLibrary:               n.UpdateLibrary,
@@ -86,6 +90,8 @@ func (n *NotificationPlex) fromNotification(notification *Notification) {
 	n.Host = notification.Host
 	n.Name = notification.Name
 	n.AuthToken = notification.AuthToken
+	n.MapFrom = notification.MapFrom
+	n.MapTo = notification.MapTo
 	n.ID = notification.ID
 	n.UpdateLibrary = notification.UpdateLibrary
 	n.Port = notification.Port
@@ -188,6 +194,16 @@ func (r *NotificationPlexResource) Schema(_ context.Context, _ resource.SchemaRe
 			"host": schema.StringAttribute{
 				MarkdownDescription: "Host.",
 				Required:            true,
+			},
+			"map_from": schema.StringAttribute{
+				MarkdownDescription: "Map from. Radarr path, used to modify movie paths when Plex sees library path location differently from Radarr (Requires 'Update Library')",
+				Optional:            true,
+				Computed:            true,
+			},
+			"map_to": schema.StringAttribute{
+				MarkdownDescription: "Map to. Plex path, used to modify movie paths when Plex sees library path location differently from Radarr (Requires 'Update Library')",
+				Optional:            true,
+				Computed:            true,
 			},
 		},
 	}

--- a/internal/provider/notification_plex_resource_test.go
+++ b/internal/provider/notification_plex_resource_test.go
@@ -25,6 +25,8 @@ func TestAccNotificationPlexResource(t *testing.T) {
 				Config: testAccNotificationPlexResourceConfig("resourcePlexTest", "token123"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("radarr_notification_plex.test", "auth_token", "token123"),
+					resource.TestCheckResourceAttr("radarr_notification_plex.test", "map_from", "/movies"),
+					resource.TestCheckResourceAttr("radarr_notification_plex.test", "map_to", "/media/movies"),
 					resource.TestCheckResourceAttrSet("radarr_notification_plex.test", "id"),
 				),
 			},
@@ -69,5 +71,9 @@ func testAccNotificationPlexResourceConfig(name, token string) string {
 		host = "plex.lcl"
 		port = 32400
 		auth_token = "%s"
+
+		update_library = true
+		map_from       = "/movies"
+		map_to         = "/media/movies"
 	}`, name, token)
 }

--- a/internal/provider/notification_resource.go
+++ b/internal/provider/notification_resource.go
@@ -616,12 +616,12 @@ func (r *NotificationResource) Schema(_ context.Context, _ resource.SchemaReques
 				Computed:            true,
 			},
 			"map_from": schema.StringAttribute{
-				MarkdownDescription: "Map From.",
+				MarkdownDescription: "Map from. Radarr path, used to modify movie paths when the media server sees library path location differently from Radarr (Requires 'Update Library')",
 				Optional:            true,
 				Computed:            true,
 			},
 			"map_to": schema.StringAttribute{
-				MarkdownDescription: "Map To.",
+				MarkdownDescription: "Map to. Media server path, used to modify movie paths when the media server sees library path location differently from Radarr (Requires 'Update Library')",
 				Optional:            true,
 				Computed:            true,
 			},

--- a/internal/provider/notifications_data_source.go
+++ b/internal/provider/notifications_data_source.go
@@ -338,11 +338,11 @@ func (d *NotificationsDataSource) Schema(_ context.Context, _ datasource.SchemaR
 							Computed:            true,
 						},
 						"map_from": schema.StringAttribute{
-							MarkdownDescription: "Map From.",
+							MarkdownDescription: "Map from. Radarr path, used to modify movie paths when the media server sees library path location differently from Radarr (Requires 'Update Library')",
 							Computed:            true,
 						},
 						"map_to": schema.StringAttribute{
-							MarkdownDescription: "Map To.",
+							MarkdownDescription: "Map to. Media server path, used to modify movie paths when the media server sees library path location differently from Radarr (Requires 'Update Library')",
 							Computed:            true,
 						},
 						"key": schema.StringAttribute{


### PR DESCRIPTION
Exposes `map_from` / `map_to` on `radarr_notification_emby` and `radarr_notification_plex`. Both are optional.

Radarr uses these to rewrite movie paths when the media server sees the library at a different location than Radarr does.
For example Radarr has `/movies` and Jellyfin has `/media/movies`.