### PR TITLE
feat: adding support for use_script_import and script_import_path for the media_management data source

### DIFF
--- a/docs/data-sources/media_management.md
+++ b/docs/data-sources/media_management.md
@@ -41,5 +41,7 @@ data "radarr_media_management" "example" {
 - `recycle_bin` (String) Recycle bin absolute path.
 - `recycle_bin_cleanup_days` (Number) Recyle bin days of retention.
 - `rescan_after_refresh` (String) Rescan after refresh policy. valid inputs are: 'always', 'afterManual' and 'never'.
+- `script_import_path` (String) Path to the script used to import downloads. Used in conjunction with 'use_script_import'.
 - `set_permissions_linux` (Boolean) Set permission for imported files.
 - `skip_free_space_check_when_importing` (Boolean) Skip free space check before importing.
+- `use_script_import` (Boolean) Use a custom script to import downloads instead of the default import logic.

--- a/docs/resources/media_management.md
+++ b/docs/resources/media_management.md
@@ -33,6 +33,8 @@ resource "radarr_media_management" "example" {
   skip_free_space_check_when_importing        = false
   minimum_free_space_when_importing           = 100
   copy_using_hardlinks                        = true
+  use_script_import                           = false
+  script_import_path                          = ""
   import_extra_files                          = true
   extra_file_extensions                       = "srt"
   enable_media_info                           = true
@@ -61,8 +63,10 @@ resource "radarr_media_management" "example" {
 - `recycle_bin` (String) Recycle bin absolute path.
 - `recycle_bin_cleanup_days` (Number) Recyle bin days of retention.
 - `rescan_after_refresh` (String) Rescan after refresh policy. valid inputs are: 'always', 'afterManual' and 'never'.
+- `script_import_path` (String) Path to the script used to import downloads. Used in conjunction with 'use_script_import'.
 - `set_permissions_linux` (Boolean) Set permission for imported files.
 - `skip_free_space_check_when_importing` (Boolean) Skip free space check before importing.
+- `use_script_import` (Boolean) Use a custom script to import downloads instead of the default import logic.
 
 ### Read-Only
 

--- a/examples/resources/radarr_media_management/resource.tf
+++ b/examples/resources/radarr_media_management/resource.tf
@@ -15,6 +15,8 @@ resource "radarr_media_management" "example" {
   skip_free_space_check_when_importing        = false
   minimum_free_space_when_importing           = 100
   copy_using_hardlinks                        = true
+  use_script_import                           = false
+  script_import_path                          = ""
   import_extra_files                          = true
   extra_file_extensions                       = "srt"
   enable_media_info                           = true

--- a/internal/provider/media_management_data_source.go
+++ b/internal/provider/media_management_data_source.go
@@ -78,6 +78,10 @@ func (d *MediaManagementDataSource) Schema(_ context.Context, _ datasource.Schem
 				MarkdownDescription: "Skip free space check before importing.",
 				Computed:            true,
 			},
+			"use_script_import": schema.BoolAttribute{
+				MarkdownDescription: "Use a custom script to import downloads instead of the default import logic.",
+				Computed:            true,
+			},
 			"minimum_free_space_when_importing": schema.Int64Attribute{
 				MarkdownDescription: "Minimum free space in MB to allow import.",
 				Computed:            true,
@@ -92,6 +96,10 @@ func (d *MediaManagementDataSource) Schema(_ context.Context, _ datasource.Schem
 			},
 			"chown_group": schema.StringAttribute{
 				MarkdownDescription: "Group used for permission.",
+				Computed:            true,
+			},
+			"script_import_path": schema.StringAttribute{
+				MarkdownDescription: "Path to the script used to import downloads. Used in conjunction with 'use_script_import'.",
 				Computed:            true,
 			},
 			"download_propers_and_repacks": schema.StringAttribute{

--- a/internal/provider/media_management_resource.go
+++ b/internal/provider/media_management_resource.go
@@ -44,6 +44,7 @@ type MediaManagement struct {
 	ExtraFileExtensions                     types.String `tfsdk:"extra_file_extensions"`
 	DownloadPropersAndRepacks               types.String `tfsdk:"download_propers_and_repacks"`
 	ChownGroup                              types.String `tfsdk:"chown_group"`
+	ScriptImportPath                        types.String `tfsdk:"script_import_path"`
 	ID                                      types.Int64  `tfsdk:"id"`
 	MinimumFreeSpaceWhenImporting           types.Int64  `tfsdk:"minimum_free_space_when_importing"`
 	RecycleBinCleanupDays                   types.Int64  `tfsdk:"recycle_bin_cleanup_days"`
@@ -57,6 +58,7 @@ type MediaManagement struct {
 	CreateEmptyMovieFolders                 types.Bool   `tfsdk:"create_empty_movie_folders"`
 	CopyUsingHardlinks                      types.Bool   `tfsdk:"copy_using_hardlinks"`
 	AutoUnmonitorPreviouslyDownloadedMovies types.Bool   `tfsdk:"auto_unmonitor_previously_downloaded_movies"`
+	UseScriptImport                         types.Bool   `tfsdk:"use_script_import"`
 }
 
 func (r *MediaManagementResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -114,6 +116,10 @@ func (r *MediaManagementResource) Schema(_ context.Context, _ resource.SchemaReq
 				MarkdownDescription: "Skip free space check before importing.",
 				Required:            true,
 			},
+			"use_script_import": schema.BoolAttribute{
+				MarkdownDescription: "Use a custom script to import downloads instead of the default import logic.",
+				Required:            true,
+			},
 			"minimum_free_space_when_importing": schema.Int64Attribute{
 				MarkdownDescription: "Minimum free space in MB to allow import.",
 				Required:            true,
@@ -128,6 +134,10 @@ func (r *MediaManagementResource) Schema(_ context.Context, _ resource.SchemaReq
 			},
 			"chown_group": schema.StringAttribute{
 				MarkdownDescription: "Group used for permission.",
+				Required:            true,
+			},
+			"script_import_path": schema.StringAttribute{
+				MarkdownDescription: "Path to the script used to import downloads. Used in conjunction with 'use_script_import'.",
 				Required:            true,
 			},
 			"download_propers_and_repacks": schema.StringAttribute{
@@ -271,11 +281,13 @@ func (m *MediaManagement) write(mediaMgt *radarr.MediaManagementConfigResource) 
 	m.PathsDefaultStatic = types.BoolValue(mediaMgt.GetPathsDefaultStatic())
 	m.SetPermissionsLinux = types.BoolValue(mediaMgt.GetSetPermissionsLinux())
 	m.SkipFreeSpaceCheckWhenImporting = types.BoolValue(mediaMgt.GetSkipFreeSpaceCheckWhenImporting())
+	m.UseScriptImport = types.BoolValue(mediaMgt.GetUseScriptImport())
 	m.ID = types.Int64Value(int64(mediaMgt.GetId()))
 	m.MinimumFreeSpaceWhenImporting = types.Int64Value(int64(mediaMgt.GetMinimumFreeSpaceWhenImporting()))
 	m.RecycleBinCleanupDays = types.Int64Value(int64(mediaMgt.GetRecycleBinCleanupDays()))
 	m.ChmodFolder = types.StringValue(mediaMgt.GetChmodFolder())
 	m.ChownGroup = types.StringValue(mediaMgt.GetChownGroup())
+	m.ScriptImportPath = types.StringValue(mediaMgt.GetScriptImportPath())
 	m.DownloadPropersAndRepacks = types.StringValue(string(mediaMgt.GetDownloadPropersAndRepacks()))
 	m.ExtraFileExtensions = types.StringValue(mediaMgt.GetExtraFileExtensions())
 	m.FileDate = types.StringValue(string(mediaMgt.GetFileDate()))
@@ -295,11 +307,13 @@ func (m *MediaManagement) read() *radarr.MediaManagementConfigResource {
 	config.SetPathsDefaultStatic(m.PathsDefaultStatic.ValueBool())
 	config.SetSetPermissionsLinux(m.SetPermissionsLinux.ValueBool())
 	config.SetSkipFreeSpaceCheckWhenImporting(m.SkipFreeSpaceCheckWhenImporting.ValueBool())
+	config.SetUseScriptImport(m.UseScriptImport.ValueBool())
 	config.SetId(int32(m.ID.ValueInt64()))
 	config.SetMinimumFreeSpaceWhenImporting(int32(m.MinimumFreeSpaceWhenImporting.ValueInt64()))
 	config.SetRecycleBinCleanupDays(int32(m.RecycleBinCleanupDays.ValueInt64()))
 	config.SetChmodFolder(m.ChmodFolder.ValueString())
 	config.SetChownGroup(m.ChownGroup.ValueString())
+	config.SetScriptImportPath(m.ScriptImportPath.ValueString())
 	config.SetDownloadPropersAndRepacks(radarr.ProperDownloadTypes(m.DownloadPropersAndRepacks.ValueString()))
 	config.SetExtraFileExtensions(m.ExtraFileExtensions.ValueString())
 	config.SetFileDate(radarr.FileDateType(m.FileDate.ValueString()))

--- a/internal/provider/media_management_resource_test.go
+++ b/internal/provider/media_management_resource_test.go
@@ -70,6 +70,8 @@ func testAccMediaManagementResourceConfig(date string) string {
 		skip_free_space_check_when_importing = false
 		minimum_free_space_when_importing = 100
 		copy_using_hardlinks = true
+		use_script_import = false
+		script_import_path = ""
 		import_extra_files = true
 		extra_file_extensions = "srt"
 		enable_media_info = true


### PR DESCRIPTION
I noticed the `media_management` resource was missing options to configure the `useScriptImport` and `scriptImportPath` ref: [here](https://radarr.video/docs/api/#/MediaManagementConfig/get_api_v3_config_mediamanagement)

Let me know if I missed anything, if this looks okay I can make a PR for the sonarr one too.